### PR TITLE
Disable sphinxcontrib.napoleon

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -35,7 +35,6 @@ sys.path.insert(0,"/Users/user/projects/pyhamtools/pyhamtools")
 # ones.
 extensions = [
     'sphinx.ext.autodoc',
-    'sphinxcontrib.napoleon',
 ]
 
 # Add any paths that contain templates here, relative to this directory.


### PR DESCRIPTION
It seems unused, and isn't packaged for Debian, so disable it to enable
building a Debian package.

The docs build without it, and I couldn't spot any problems with the generated html files.