### PR TITLE
Updating eSwatini to  Eswatini

### DIFF
--- a/pyhamtools/countryfilemapping.json
+++ b/pyhamtools/countryfilemapping.json
@@ -1,7 +1,7 @@
 {
   "Canada": 1,
   "Kingman Reef": 134,
-  "Kingdom of eSwatini": 468,
+  "Kingdom of Eswatini": 468,
   "Cameroon": 406,
   "Burkina Faso": 480,
   "Turkmenistan": 280,


### PR DESCRIPTION
Based on current country-files.com data its now listed as Kingdom of Eswantini

This matches to what Wikipedia is saying as well https://en.wikipedia.org/wiki/Eswatini


from http://country-files.com/cty/cty.plist 
`<key>3DA</key>
  <dict>
  <key>Country</key>
  <string>Kingdom of Eswatini</string>
  <key>Prefix</key>
  <string>3DA</string>
  <key>ADIF</key>
  <integer>468</integer>
  <key>CQZone</key>
  <integer>38</integer>
  <key>ITUZone</key>
  <integer>57</integer>
  <key>Continent</key>
  <string>AF</string>
  <key>Latitude</key>
  <real>-26.65</real>
  <key>Longitude</key>
  <real>-31.48</real>
  <key>GMTOffset</key>
  <real>-2.0</real>
  <key>ExactCallsign</key>
  <false/>
  </dict>`
