### PR TITLE
Docs: Fix redis related example in docstring

### DIFF
--- a/pyhamtools/lookuplib.py
+++ b/pyhamtools/lookuplib.py
@@ -176,7 +176,7 @@ class LookupLib(object):
            >>> from pyhamtools import LookupLib
            >>> import redis
            >>> r = redis.Redis()
-           >>> my_lookuplib = LookupLib(lookuptype="countryfile", redis_instance=r, redis_prefix="CF")
+           >>> my_lookuplib = LookupLib(lookuptype="redis", redis_instance=r, redis_prefix="CF")
            >>> my_lookuplib.lookup_callsign("3D2RI")
            {
              u'adif': 460,


### PR DESCRIPTION
This docstring demonstrates how to use Redis to query the data. However, Redis is NOT actually getting used due to `lookuptype="countryfile"` argument instead of the required `lookuptype="redis" argument.

Thanks for writing this neat library :heart: 