### PR TITLE
Python 3.9 removed the json.loads(encoding) keyword argument and the …

### DIFF
--- a/pyhamtools/lookuplib.py
+++ b/pyhamtools/lookuplib.py
@@ -1426,9 +1426,10 @@ class LookupLib(object):
         mapping = None
 
         with open(country_mapping_filename, "r") as f:
-            mapping = json.loads(f.read(),encoding='UTF-8')
+            mapping = json.loads(f.read())
 
-        cty_list = plistlib.readPlist(cty_file)
+        with open(cty_file, 'rb') as f:
+            cty_list = plistlib.load(f)
 
         for item in cty_list:
             entry = {}
@@ -1514,7 +1515,7 @@ class LookupLib(object):
         Deserialize a JSON into a dictionary
         """
 
-        my_dict = json.loads(json_data.decode('utf8'), encoding='UTF-8')
+        my_dict = json.loads(json_data.decode('utf8'))
 
         for item in my_dict:
             if item == const.ADIF:

--- a/pyhamtools/qsl.py
+++ b/pyhamtools/qsl.py
@@ -121,7 +121,7 @@ def get_clublog_users(**kwargs):
     files = zip_file.namelist()
     cl_json_unzipped = zip_file.read(files[0]).decode('utf8').replace("'", '"')
 
-    cl_data = json.loads(cl_json_unzipped, encoding='UTF-8')
+    cl_data = json.loads(cl_json_unzipped)
 
     error_count = 0
 


### PR DESCRIPTION
…old plistlib API.

This is probably not everything that needs updating for 3.9, but it made the Debian package tests pass.