### PR TITLE
Update debian package name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ Christoph, [@df7cb](https://github.com/df7cb) is kindly maintaining a Debian pac
 
 ```bash
 
-$ sudo apt-get install pyhamtools
+$ sudo apt-get install python3-pyhamtools
 
 ```
 


### PR DESCRIPTION
The README.md refers to @df7cb's debian package as pyhamtools, but the package name is actually python3-pyhamtools.   
